### PR TITLE
Proposed fix for FAIL report for Perl v5.26.

### DIFF
--- a/t/init.t
+++ b/t/init.t
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+BEGIN { push @INC, '.'; }
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.
It propose fix for the following FAIL reports.

https://www.cpantesters.org/cpan/report/437f108c-29e6-11e9-81f5-45cc7247484a
https://www.cpantesters.org/cpan/report/c0edb1c8-29e5-11e9-937b-b8177347484a
https://www.cpantesters.org/cpan/report/b7ecec8c-29e1-11e9-a481-1d2d7347484a
https://www.cpantesters.org/cpan/report/9d3b1f26-29dc-11e9-b804-56c47247484a

If I am not mistaken then this is caused by the removal "." from @INC in Perl v5.26. Here is link for more details.
https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC

Many Thanks.
Best Regards,
Mohammad S Anwar